### PR TITLE
Adapt contributing file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,9 +3,7 @@
 ### Fixing typos
 
 Small typos or grammatical errors in documentation may be edited directly using the GitHub web interface, so long as the changes are made in the _source_ file.
-
-*  YES: you edit a roxygen comment in a `.R` file below `R/`.
-*  NO: you edit an `.Rd` file below `man/`.
+E.g. edit a roxygen comment in a `.R` file below `R/`, not in an `.Rd` file below `man/`.
 
 ### Prerequisites
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Contributions with test cases included are easier to accept.
 
 ### Code of Conduct
 
-Please note that the git2rdata project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
 By contributing to this project you agree to abide by its terms.
 
 ### Prefer to Email? 

--- a/codemeta.json
+++ b/codemeta.json
@@ -274,7 +274,7 @@
       "sameAs": "https://CRAN.R-project.org/package=yaml"
     }
   ],
-  "fileSize": "143.358KB",
+  "fileSize": "0KB",
   "contIntegration": "https://codecov.io/gh/inbo/checklist?branch=master",
   "developmentStatus": ["https://www.repostatus.org/#wip", "https://www.tidyverse.org/lifecycle/#experimental"],
   "codeRepository": "https://github.com/inbo/checklist",

--- a/inst/package_template/CONTRIBUTING.md
+++ b/inst/package_template/CONTRIBUTING.md
@@ -3,9 +3,7 @@
 ### Fixing typos
 
 Small typos or grammatical errors in documentation may be edited directly using the GitHub web interface, so long as the changes are made in the _source_ file.
-
-*  YES: you edit a roxygen comment in a `.R` file below `R/`.
-*  NO: you edit an `.Rd` file below `man/`.
+E.g. edit a roxygen comment in a `.R` file below `R/`, not in an `.Rd` file below `man/`.
 
 ### Prerequisites
 

--- a/inst/package_template/CONTRIBUTING.md
+++ b/inst/package_template/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Contributions with test cases included are easier to accept.
 
 ### Code of Conduct
 
-Please note that the git2rdata project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
 By contributing to this project you agree to abide by its terms.
 
 ### Prefer to Email? 


### PR DESCRIPTION
This PR implements the changes suggested in issue #15. Changes are made in both the template and the contributing file of this package.

I simply removed 'git2rdata' and did not replace it by the newly created package name, as the latter requires to change the `md` file to a `Rmd` file (which did in my opinion not outweigh the rather small advantage of having the package name in the contributing file).  Please let me know if you prefer to have to add the package name in it anyway.

I suppose this small change does not need to be added to the news file?