### PR TITLE
Fix ignored filenames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: checklist
 Title: A Thorough and Strict Set of Checks for R Packages and Source Code
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "Thierry",
              family = "Onkelinx",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# checklist 0.1.11
+
+## Bugfixes
+
+* Exclude `*.Rproj` filename from the check for filenames (avoids a warning when
+  a hyphen is used in the repositories name)
+
 # checklist 0.1.10
 
 ## User visible changes

--- a/R/check_filename.R
+++ b/R/check_filename.R
@@ -99,7 +99,7 @@ Failing folder: `%s`",
   )
 
   # ignore git and RStudio files
-  files <- files[!grepl("\\.(git|Rproj.user)/.*", files)]
+  files <- files[!grepl("(\\.(git|Rproj.user)/.*)|(\\.Rproj$)", files)]
   # ignore some standardised files
   re <- sprintf(
     "^(%s)$",


### PR DESCRIPTION
`checklist::check_filename()` checks the `*.Rproj` file generated by Rstudio. I think this file should be ignored to avoid warning about use of hyphen in that filename. Related to #50 (the fix in #51 only addressed the lintr aspect).