### PR TITLE
just a typo

### DIFF
--- a/R/read_checklist.R
+++ b/R/read_checklist.R
@@ -24,7 +24,7 @@ read_checklist <- function(x = ".") {
   if (!file_test("-f", checklist_file)) {
     # no check list file found
     message("No `checklist.yml` found. Assuming this is a package.
-See `?write_checklist()` to generate a `checklist.yml`.")
+See `?write_checklist` to generate a `checklist.yml`.")
     x <- x$allowed()
     return(x)
   }


### PR DESCRIPTION
When accessing help using `?`, you don't need parentheses (and it even doesn't work with parentheses)