### PR TITLE
V0.2.7

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "checklist: A Thorough and Strict Set of Checks for R Packages and Source Code",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "An opinionated set of rules for R packages and R source code projects.",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ contact:
 - email: info@inbo.be
   name: Research Institute for Nature and Forest
 title: 'checklist: A Thorough and Strict Set of Checks for R Packages and Source Code'
-version: 0.2.6
+version: 0.2.7
 abstract: An opinionated set of rules for R packages and R source code projects.
 license: GPL-3.0
 type: software

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: checklist
 Title: A Thorough and Strict Set of Checks for R Packages and Source Code
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(
     person("Thierry", "Onkelinx", , "thierry.onkelinx@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8804-4216")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# checklist 0.2.7
+
+* fixes a note about `"MIT"` license
+
 # checklist 0.2.6
 
 * `check_license()` allows `"MIT"` license in addition to `"GPLv3"` for packages

--- a/R/check_description.R
+++ b/R/check_description.R
@@ -221,7 +221,7 @@ check_license <- function(x = ".") {
 Please send a pull request if you need support for this license.",
       this_desc$get_field("License")
     )[
-      !current_license %in% c("GPL-3", "MIT")
+      !current_license %in% c("GPL-3", "MIT + file LICENSE")
     ]
   } else {
     current_license <- "CC-BY"
@@ -240,18 +240,18 @@ Please send a pull request if you need support for this license.",
   current <- switch(
     current_license,
     "GPL-3" = readLines(file.path(x$get_path, "LICENSE.md")),
-    "MIT" = readLines(file.path(x$get_path, "LICENSE.md")),
+    "MIT + file LICENSE" = readLines(file.path(x$get_path, "LICENSE.md")),
     "CC-BY" = readLines(file.path(x$get_path, "LICENSE.md"))
     )
   official <- switch(
     current_license,
     "GPL-3" = "gplv3.md",
-    "MIT" = "mit.md",
+    "MIT + file LICENSE" = "mit.md",
     "CC-BY" = "cc_by_4_0.md"
   )
   system.file("generic_template", official, package = "checklist") |>
     readLines() -> official
-  if (current_license == "MIT") {
+  if (current_license == "MIT + file LICENSE") {
     author <- this_desc$get_author(role = "cph")
     cph <- paste(c(author$given, author$family), collapse = " ")
     problems <- c(

--- a/R/create_package.R
+++ b/R/create_package.R
@@ -119,7 +119,7 @@ RoxygenNote: %5$s
     paste(format(maintainer, style = "R"), collapse = "\n"),
     description,
     installed.packages()["roxygen2", "Version"], language,
-    license
+    ifelse(license == "MIT", "MIT + file LICENSE", license)
   )
   writeLines(description, path(path, "DESCRIPTION"))
   tidy_desc(path)
@@ -196,9 +196,16 @@ RoxygenNote: %5$s
     path(path, "LICENSE.md")
   )
   if (license == "MIT") {
+    writeLines(
+      c(paste0("YEAR: ", format(Sys.Date(), "%Y")),
+        "COPYRIGHT HOLDER: Research Institute for Nature and Forest"
+        ),
+      path(path, "LICENSE")
+      )
+    git_add("LICENSE", repo = repo)
     mit <- readLines(file.path(path, "LICENSE.md"))
     mit[3] <- gsub("<YEAR>", format(Sys.Date(), "%Y"), mit[3])
-    mit[3] <- gsub("<COPYRIGHT HOLDERS>",
+    mit[3] <- gsub("<COPYRIGHT HOLDER>",
                    "Research Institute for Nature and Forest",
                    mit[3])
     writeLines(mit, file.path(path, "LICENSE.md"))

--- a/R/setup_package.R
+++ b/R/setup_package.R
@@ -119,6 +119,13 @@ setup_package <- function(path = ".",
       path(path, "LICENSE.md")
     )
     if (license == "MIT") {
+      writeLines(
+        c(paste0("YEAR: ", format(Sys.Date(), "%Y")),
+          "COPYRIGHT HOLDER: Research Institute for Nature and Forest"
+        ),
+        path(path, "LICENSE")
+      )
+      git_add("LICENSE", force = TRUE, repo = path)
       mit <- readLines(path(path, "LICENSE.md"))
       mit[3] <- gsub("<YEAR>", format(Sys.Date(), "%Y"), mit[3])
       mit[3] <- gsub("<COPYRIGHT HOLDERS>",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,12 +2,12 @@ citHeader("To cite `checklist` in publications please use:")
 # begin checklist entry
 citEntry(
   entry = "Manual",
-  title = "checklist: A Thorough and Strict Set of Checks for R Packages and Source Code. Version 0.2.6",
+  title = "checklist: A Thorough and Strict Set of Checks for R Packages and Source Code. Version 0.2.7",
   author = c(person(given = "Thierry", family = "Onkelinx")),
   year = 2022,
   url = "https://inbo.github.io/checklist/",
   abstract = "An opinionated set of rules for R packages and R source code projects.",
-  textVersion = "Onkelinx, Thierry (2022) checklist: A Thorough and Strict Set of Checks for R Packages and Source Code. Version 0.2.6. https://inbo.github.io/checklist/, https://github.com/inbo/checklist, https://doi.org/10.5281/zenodo.4028303",
+  textVersion = "Onkelinx, Thierry (2022) checklist: A Thorough and Strict Set of Checks for R Packages and Source Code. Version 0.2.7. https://inbo.github.io/checklist/, https://github.com/inbo/checklist, https://doi.org/10.5281/zenodo.4028303",
   keywords = "R package, quality control",
   doi = "10.5281/zenodo.4028303",
 )

--- a/inst/generic_template/mit.md
+++ b/inst/generic_template/mit.md
@@ -1,6 +1,6 @@
-MIT License
+# MIT License
 
-Copyright (c) <YEAR> <COPYRIGHT HOLDERS>
+Copyright (c) <YEAR> <COPYRIGHT HOLDER>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/tests/testthat/test_d_check_license.R
+++ b/tests/testthat/test_d_check_license.R
@@ -32,6 +32,10 @@ test_that("check_license() works", {
     paste0("Copyright (c) ", format(Sys.Date(), "%Y"),
            " Research Institute for Nature and Forest")
   )
+  expect_identical(
+    file.exists(file.path(repo, "LICENSE")),
+    TRUE
+  )
   # copyright holder mismatch
   mit[3] <- paste0("Copyright (c) ", format(Sys.Date(), "%Y"),
                    " INBO")


### PR DESCRIPTION
In case of a MIT license, a `LICENSE` file is needed in addition to a `LICENSE.md`. See https://r-pkgs.org/license.html and https://cran.rstudio.com/doc/manuals/r-devel/R-exts.html#Licensing.

This PR makes some changes to address this issue.
The test for `check_license()` covers the case `create_package(..., license = "MIT")`.