### PR TITLE
Remove extra space after `roles`

### DIFF
--- a/R/citation_meta_class.R
+++ b/R/citation_meta_class.R
@@ -116,7 +116,7 @@ citation_print <- function(errors, meta, notes, path, warnings) {
     cat("\n  affiliation:", meta$authors$affiliation[i])
     cat("\n  orcid:", meta$authors$orcid[i])
     cat(
-      "\n  roles: ",
+      "\n  roles:",
       paste(
         meta$roles$role[meta$roles$contributor == meta$authors$id[i]],
         collapse = "; "


### PR DESCRIPTION
To avoid:
```
- given: Research Institute for Nature and Forest (INBO)
  family:
  affiliation:
  orcid:
  roles:  copyright holder
```