### PR TITLE
Update citation_meta_class.R

### DIFF
--- a/R/citation_meta_class.R
+++ b/R/citation_meta_class.R
@@ -229,6 +229,7 @@ validate_citation <- function(meta) {
 #' @importFrom fs path
 #' @importFrom jsonlite toJSON
 #' @importFrom knitr pandoc
+#' @importFrom gert git_find
 citation_zenodo <- function(meta) {
   assert_that(inherits(meta, "citation_meta"))
   assert_that(length(meta$get_errors) == 0)
@@ -300,7 +301,7 @@ citation_zenodo <- function(meta) {
     "Please commit changes."
   )[
     !is_tracked_not_modified(
-      path_rel(citation_file, meta$get_path), meta$get_path
+      path_rel(citation_file, git_find(meta$get_path)), meta$get_path
     )
   ]
   return(errors)

--- a/R/citation_meta_class.R
+++ b/R/citation_meta_class.R
@@ -300,6 +300,7 @@ citation_zenodo <- function(meta) {
     "Run `checklist::update_citation()` locally."[!interactive()],
     "Please commit changes."
   )[
+    is_repository(meta$get_path) &&
     !is_tracked_not_modified(
       path_rel(citation_file, git_find(meta$get_path)), meta$get_path
     )


### PR DESCRIPTION
This should fix a bug where `.zenodo.json` file was incorrectly flagged as modified. The relative path to the file should be relative to the root of the git repository. This failed in cases where `meta$get_path` is a child directory beneath the git root repository. The `gert` package uses `gert::git_find` to find the git parent directory in case a child directory is passed to the `repo = ` argument.
So the proposed change should make sure that the `file` argument in `is_tracked_not_modified` is relative to the path passed to its `repo` argument (which gets passed down to repo argument of `gert` functions and thus resolve to `gert::git_find(repo)`.